### PR TITLE
商品詳細ページ表示・削除/編集ボタン切り替え実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,10 @@ class ItemsController < ApplicationController
   before_action :move_to_index, only: [:new]
   def index
     @item = Item.all.order(created_at: "DESC")
+  end
 
+  def show
+    @item = Item.find(params[:id])
   end
 
   def new

--- a/app/javascript/price.js
+++ b/app/javascript/price.js
@@ -2,11 +2,11 @@ window.addEventListener('load', () => {
   const price = document.getElementById("item-price");
   const tax = document.getElementById("add-tax-price");
   const profit = document.getElementById("profit");
-  price.value = 0;
+  console.log("ok", price)
 
-    price.addEventListener('input', function(){
-      const sell_price = price.value;
-      tax.innerHTML = sell_price * 0.1;
-      profit.innerHTML = sell_price * 0.9;
+  price.addEventListener('input', function(){
+    const sell_price = price.value;
+    tax.innerHTML = sell_price * 0.1;
+    profit.innerHTML = sell_price * 0.9;
   });
 });

--- a/app/javascript/price.js
+++ b/app/javascript/price.js
@@ -2,7 +2,6 @@ window.addEventListener('load', () => {
   const price = document.getElementById("item-price");
   const tax = document.getElementById("add-tax-price");
   const profit = document.getElementById("profit");
-  console.log("ok", price)
 
   price.addEventListener('input', function(){
     const sell_price = price.value;

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
       
       <li class='list'>
         <% @item.each do |item| %>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
@@ -155,8 +155,6 @@
         <% end %>
       </li>
 
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% if @item.count == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -176,8 +174,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -79,7 +79,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:days_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,16 +24,16 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user.id%> <%#購入機能を実装後、"購入されていない商品であること"の条件を付け加える。%>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% elsif user_signed_in? %> <%#購入機能を実装後、"購入されていない商品であること"の条件を付け加える。%>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
@@ -43,27 +43,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.cost_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -37,7 +37,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -70,7 +70,7 @@
     <div class="option">
       <div class="favorite-btn">
         <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
+        <span>お気に入り </span>
       </div>
       <div class="report-btn">
         <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
@@ -102,7 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/db/migrate/20201028074252_rename_days_id_column_to_items.rb
+++ b/db/migrate/20201028074252_rename_days_id_column_to_items.rb
@@ -1,0 +1,5 @@
+class RenameDaysIdColumnToItems < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :items, :days_id, :day_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_23_150315) do
+ActiveRecord::Schema.define(version: 2020_10_28_074252) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2020_10_23_150315) do
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "price", null: false
-    t.integer "days_id", null: false
+    t.integer "day_id", null: false
     t.integer "area_id", null: false
     t.integer "cost_burden_id", null: false
     t.integer "status_id", null: false


### PR DESCRIPTION
 ## What
- 商品詳細画面実装
- 非ログイン時、購入ボタン/削除ボタン/編集ボタンが表示されない
https://gyazo.com/2505af80853f156442a9a5b643f147eb
- 出品者以外のログインユーザーの場合、購入ボタンが表示され、削除ボタン/編集ボタンが非表示になる。
https://gyazo.com/f9b53051cbbdcfb3bce9728277ef0f33
 - 出品者がアクセスした際、削除ボタン/編集ボタンが表示され、購入ボタンが非表示になる。
https://gyazo.com/64249a9a5c3f0d7f42d0707e22a6c052

## Why
- 非ログインユーザーに購入・削除・編集をさせないため。
- 出品者以外のユーザーに削除・編集をさせないため。
- 出品者が購入しないようにするため。