### PR TITLE
商品情報編集機能実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 |status_id          |integer        |null: false                   |
 |cost_burden_id     |integer        |null: false                   |
 |area_id            |integer        |null: false                   |
-|days_id            |integer        |null: false                   |
+|day_id            |integer        |null: false                   |
 |price              |integer        |null: false                   |
 |user               |references     |null: false  foreign_key: true|
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,12 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, only: [:new]
+  before_action :move_to_index, only: [:new, :edit]
+  before_action :params_id, only: [:edit, :show, :update]
+  
   def index
     @item = Item.all.order(created_at: "DESC")
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def new
@@ -13,7 +14,7 @@ class ItemsController < ApplicationController
   end
 
   def create
-    @item = Item.new(item_params)
+    @item = Item.new(set_params)
     if @item.save
       redirect_to root_path
     else
@@ -21,10 +22,30 @@ class ItemsController < ApplicationController
     end
   end
 
+  def edit
+    unless current_user.id == @item.user_id
+      redirect_to root_path
+    end
+    # 購入機能実装後、出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
+    
+  end
+
+  def update
+    if @item.update(set_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
+
   private
 
-  def item_params
-    params.require(:item).permit(:user_id, :price, :days_id, :area_id, :cost_burden_id, :status_id, :category_id, :description, :name, :image).merge(user_id: current_user.id)
+  def params_id
+    @item = Item.find(params[:id])
+  end
+
+  def set_params
+    params.require(:item).permit(:price, :day_id, :area_id, :cost_burden_id, :status_id, :category_id, :description, :name, :image).merge(user_id: current_user.id)
   end
 
   def move_to_index
@@ -32,4 +53,5 @@ class ItemsController < ApplicationController
       redirect_to user_session_path
     end
   end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, only: [:new, :edit]
+  before_action :authenticate_user!, only: [:new, :edit]
   before_action :params_id, only: [:edit, :show, :update]
   
   def index
@@ -46,12 +46,6 @@ class ItemsController < ApplicationController
 
   def set_params
     params.require(:item).permit(:price, :day_id, :area_id, :cost_burden_id, :status_id, :category_id, :description, :name, :image).merge(user_id: current_user.id)
-  end
-
-  def move_to_index
-    unless user_signed_in?
-      redirect_to user_session_path
-    end
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,7 @@ class Item < ApplicationRecord
 
   with_options presence: true do
     validates :price
-    validates :days_id
+    validates :day_id
     validates :area_id
     validates :cost_burden_id
     validates :status_id
@@ -20,7 +20,7 @@ class Item < ApplicationRecord
     validates :image
   end
 
-  validates :days_id, :area_id, :cost_burden_id, :status_id, :category_id, numericality: { other_than: 1 }
+  validates :day_id, :area_id, :cost_burden_id, :status_id, :category_id, numericality: { other_than: 1 }
 
   validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,3 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
@@ -7,13 +5,12 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
-    <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
         出品画像
@@ -23,28 +20,25 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-    <%# /出品画像 %>
-    <%# 商品名と商品説明 %>
+
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
 
-    <%# 商品の詳細 %>
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -52,15 +46,14 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
-    <%# /商品の詳細 %>
 
     <%# 配送について %>
     <div class="items-detail">
@@ -73,22 +66,22 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:cost_burden_id, CostBurden.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
 
-    <%# 販売価格 %>
+
     <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
@@ -101,7 +94,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -117,9 +110,7 @@ app/assets/stylesheets/items/new.css %>
         </div>
       </div>
     </div>
-    <%# /販売価格 %>
 
-    <%# 注意書き %>
     <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
@@ -137,13 +128,12 @@ app/assets/stylesheets/items/new.css %>
         に同意したことになります。
       </p>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
+
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
+
   </div>
   <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user.id%> <%#購入機能を実装後、"購入されていない商品であること"の条件を付け加える。%>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% elsif user_signed_in? %> <%#購入機能を実装後、"購入されていない商品であること"の条件を付け加える。%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
   
-  resources :items, only: [:index, :new, :show, :create]
+  resources :items, only: [:index, :new, :show, :create, :edit, :update]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :item do
     price               { Faker::Number.between(from: 300, to: 9_999_999) }
-    days_id             { Faker::Number.between(from: 2, to: 4) }
+    day_id             { Faker::Number.between(from: 2, to: 4) }
     area_id             { Faker::Number.between(from: 2, to: 48) }
     cost_burden_id      { Faker::Number.between(from: 2, to: 3) }
     status_id           { Faker::Number.between(from: 2, to: 7) }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Area must be other than 1')
       end
       it '発送までの日数が空だと登録できない' do
-        @item.days_id = 1
+        @item.day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Days must be other than 1')
+        expect(@item.errors.full_messages).to include('Day must be other than 1')
       end
       it '販売価格が空だと登録できない' do
         @item.price = ''


### PR DESCRIPTION
### What
- 商品詳細ページから、編集するボタンを押すと、商品情報編集ページに遷移する。
https://gyazo.com/9d8734b78ef4ad0ab55ad93d8f09ce59
- 出品者以外のログインユーザーがURLを直接入力しても、編集ページに遷移しない。
https://gyazo.com/b968637f1593632ac1233b8f2f82e129
- ログインしていないユーザーがURLを直接入力すると、ログイン画面に遷移する。
https://gyazo.com/c0996cf65062fa4c1ad91e6c6aaf8dfe
- 商品情報に不備があった場合、編集ページの上部にエラーが表示される。
https://gyazo.com/82745c081db0d5d85910baf7e01055c1

### Why
- 出品者にしか表示されない編集ボタンにより、他社のアクセスを防ぐ。
- 出品者以外のアクセスを防ぐため。
- 出品者以外のアクセスを防ぐため。
- 誤った商品情報が入力されるのを防ぐため。